### PR TITLE
Upgrade flet from 0.84.0 to 0.85.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,15 @@ authors = [
     { name = "Flet developer", email = "you@example.com" }
 ]
 dependencies = [
-    "flet==0.84.0",
+    "flet>=0.85.3",
     "chess>=1.11.2",
 ]
 
 [dependency-groups]
 dev = [
-    "flet-cli>=0.81.0",
-    "flet-desktop>=0.81.0",
-    "flet-web>=0.81.0",
+    "flet-cli>=0.85.3",
+    "flet-desktop>=0.85.3",
+    "flet-web>=0.85.3",
     "pytest>=9.0.3",
 ]
 


### PR DESCRIPTION
No code changes required - project already uses modern API forms (ft.Border.all, ft.Padding.all, no deprecated DragTargetEvent fields). All 105 tests pass.